### PR TITLE
Flaky Test Fixed in testDateAfterBefore_fail_both()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 *.log
+core/.nondex
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImplTest.java
@@ -1013,13 +1013,13 @@ public class ZeroCodeAssertionsProcessorImplTest {
 
         assertThat(failedReports.size(), is(2));
         assertThat(
-                failedReports.get(0).toString(),
-                is(
+                failedReports.toString(),
+                containsString(
                         "Assertion jsonPath '$.body.projectDetails.startDateTime' with actual value '2017-04-14T11:49:56.000Z' "
                                 + "did not match the expected value 'Date Before:2016-09-14T09:49:34'"));
         assertThat(
-                failedReports.get(1).toString(),
-                is(
+                failedReports.toString(),
+                containsString(
                         "Assertion jsonPath '$.body.projectDetails.endDateTime' with actual value '2018-11-12T09:39:34.000Z' "
                                 + "did not match the expected value 'Date After:2019-09-14T09:49:34'"));
     }


### PR DESCRIPTION
Flaky Test Commit SHA: ad6c834c8e19f283302b029b5e697e63d62ea157
Flaky Test Path: "_org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeAssertionsProcessorImplTest.testDateAfterBefore_fail_both_"

**Problem with test:** The test method in the path above does not take into consideration the lack of fixed order property of the array list used to store the **_Asserters_**, thus, this causes the assert methods to fail at times as the order of the insertion is swapped during different runs. Since the assert methods to test the code get the 0th element and 1st element and check if they are equal to a specific string when the order is shuffled, the test fails when it actually works fine.

**Solution to flaky test:** The solution to this flaky test was quite simple, it is to change the assert statements to check if the ArrayList of JSONAsserters contains the specific JSON string instead of comparing it to a specific value in the ArrayList. Using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool to test for flaky tests, it was run 20 times where there was shuffling of the orders in each run and the assert methods passed all 20 runs. 

To execute the maven test without and with the NonDex tool execute these commands from the root folder:

1. `mvn install -DskipTests -pl core` -  this compiles the specific submodule `core`
2. `mvn test -pl core -Dtest=org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeAssertionsProcessorImplTest#testDateAfterBefore_fail_both` - this runs a test on the specified method in the submodule `core` and should output **_build success_**
3. `mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl core -Dtest=org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeAssertionsProcessorImplTest#testDateAfterBefore_fail_both -DnondexRuns=20` - this test uses the NonDex tool to rigorously test the test methods to check for any flaky tests. Without the aforementioned changes, running this command will return **_build failed_**. However, with the changes in this PR, running this command will pass all 20 runs and return **_build success_**.
